### PR TITLE
Add support for $contains for search in arrays

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -37,6 +37,12 @@ export default function parseQuery(service, reQuery, params) {
             return doc(qField).match(qValue.$regexp);
           }); 
           break;
+        case '$contains':
+          isFilter = true;
+          reQuery = reQuery.filter(function (doc) {
+            return doc(qField).contains(qValue.$contains);
+          });
+          break;
         case '$lt':
           subQuery = r.row(qField).lt(params[qField].$lt);
           break;


### PR DESCRIPTION
According to: https://rethinkdb.com/api/javascript/filter/#more-complex-predicates with $contains can filter by array value.

For example, if have a tables 'users' and 'places' and the relation between this tables is stored in the 'placesVisited' field on 'users' table as array of 'places.id' field, we can get all users that visit "France".
