### PR TITLE
Add support for $btwn and $nbtwn

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -19,6 +19,14 @@ export default function parseQuery(service, reQuery, params) {
          *  becomes
          *  r.expr(['Alice', 'Bob']).contains(doc['name'])
          */
+        case '$btwn':
+          isFilter = true;
+		      reQuery = reQuery.filter(r.row(qField).ge(qValue.$btwn[0])).filter(r.row(qField).le(qValue.$btwn[1]));
+          break;
+        case '$nbtwn':
+          isFilter = true;
+		      reQuery = reQuery.filter(r.row(qField).lt(qValue.$nbtwn[0]).or(r.row(qField).gt(qValue.$nbtwn[1])));
+          break;
         case '$in':
           isFilter = true;
           reQuery = reQuery.filter(function(doc) {


### PR DESCRIPTION
Add support for between and not between operations: 

Example:

```
query.dateField = { $btwn: [ '2016-01-01', '2016-02-02' ] }
query.dateField = { $nbtwn: [ '2016-01-01', '2016-02-02' ] }
```

@TO-DO: Use https://rethinkdb.com/api/javascript/between/ instead
