### PR TITLE
Fixes undefined res.generated_keys on create() when doc submitted w/ an id

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -170,7 +170,7 @@ class Service {
   create(data) {
     return this.table.insert(data).run()
       .then(res => Object.assign({
-        id: res.generated_keys[0]
+        id: (data.id ? data.id : res.generated_keys[0])
       }, data));
   }
 


### PR DESCRIPTION
Scenario:
I create a doc like {id: "my-identifier", something: "content"}

- Behaviour before: create() throws error res.generated_keys is undefined
- Behaviour after PR, create() returns the correct id as part of the doc