### PR TITLE
Accept string or integer `$sort` param

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -56,7 +56,7 @@ class Service {
     // Handle $sort
     if (filters.$sort) {
       let fieldName = Object.keys(filters.$sort)[0];
-      if (filters.$sort[fieldName] === 1) {
+      if (filters.$sort[fieldName] == 1) {
         q = q.orderBy(fieldName);
       } else {
         q = q.orderBy(r.desc(fieldName));


### PR DESCRIPTION
When using a Rest provider, doing a `$sort[id]=1` query will result in the `filters.$sort['id']` to result in string `'1'` rather than an integer causing the `===` equality to fail. Reducing the equality check from `===` to `==` solves the issue.