### PR TITLE
Initialize Database

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,7 @@ var app = feathers()
     .then(() => {
       // mount the service
       app.use('messages', messages);
-
-      // Start the server.
+      // start the server.
       const port = 3030;
       app.listen(port, function() {
         console.log(`Feathers server listening on port ${port}`);

--- a/README.md
+++ b/README.md
@@ -59,35 +59,28 @@ var app = feathers()
   .use(bodyParser.json())
   // Turn on URL-encoded parser for REST services
   .use(bodyParser.urlencoded({extended: true}));
+  
+  var messages = service({
+    Model: r,
+    name: 'messages',
+    paginate: {
+      default: 10,
+      max: 50
+    }
+  }))
 
-// Create your database if it doesn't exist.
-r.dbList().contains('feathers')
-  .do(dbExists => r.branch(dbExists, {created: 0}, r.dbCreate('feathers'))).run()
+  messages
+    .init()
+    .then(() => {
+      // mount the service
+      app.use('messages', messages);
 
-  // Create the table if it doesn't exist.
-  .then(() => {
-    return r.db('feathers').tableList().contains('messages')
-      .do(tableExists => r.branch( tableExists, {created: 0}, r.tableCreate('messages'))).run();
-  })
-
-  // Create and register a Feathers service.
-  .then(() => {
-    app.use('messages', service({
-      Model: r,
-      name: 'messages',
-      paginate: {
-        default: 10,
-        max: 50
-      }
-    }));
-  })
-  .catch(err => console.log(err));
-
-// Start the server.
-var port = 3030;
-app.listen(port, function() {
-  console.log(`Feathers server listening on port ${port}`);
-});
+      // Start the server.
+      const port = 3030;
+      app.listen(port, function() {
+        console.log(`Feathers server listening on port ${port}`);
+      });
+    })
 ```
 
 You can run this example by using `node example/app` and going to [localhost:3030/messages](http://localhost:3030/messages). You should see an empty array. That's because you don't have any Todos yet but you now have full CRUD for your new messages service.

--- a/example/app.js
+++ b/example/app.js
@@ -50,13 +50,11 @@ let app = feathers()
     extended: true
   }));
 
-module.exports = todoService.init()
+module.exports = todoService
+  .init()
   .then(() => {
     // mount the service
     app.use('/todos', todoService);
     // start the server
-    const port = 3030;
-    return app.listen(port, function () {
-      console.log(`Feathers server listening on port ${port}`);
-    });
+    return app.listen(3030);
   });

--- a/example/app.js
+++ b/example/app.js
@@ -10,16 +10,6 @@ const r = rethink({
   db: 'feathers'
 });
 
-r.db('feathers').tableList().contains('todos')
-  .do(function (tableExists) {
-    return r.branch(
-      tableExists, {
-        created: 0
-      },
-      r.db('feathers').tableCreate('todos')
-    );
-  }).run();
-
 let counter = 0;
 const todoService = service({
   Model: r,
@@ -58,11 +48,15 @@ let app = feathers()
   // Turn on URL-encoded parser for REST services
   .use(bodyParser.urlencoded({
     extended: true
-  }))
-  .use('/todos', todoService);
+  }));
 
-// Start the server.
-const port = 3030;
-
-// require('http').createServer();
-module.exports = app.listen(port);
+module.exports = todoService.init()
+  .then(() => {
+    // mount the service
+    app.use('/todos', todoService);
+    // start the server
+    const port = 3030;
+    return app.listen(port, function () {
+      console.log(`Feathers server listening on port ${port}`);
+    });
+  });

--- a/src/index.js
+++ b/src/index.js
@@ -41,6 +41,18 @@ class Service {
     return Proto.extend(obj, this);
   }
 
+  init (table, opts = {}) {
+    let r = this.options.r;
+    let db = this.options.r._poolMaster._options.db;
+
+    return r.dbList().contains(db) // create db if not exists
+      .do(dbExists => r.branch(dbExists, {created: 0}, r.dbCreate(db))).run()
+      .then(() => {
+        return r.db(db).tableList().contains(table) // create table if not exists
+          .do(tableExists => r.branch(tableExists, {created: 0}, r.tableCreate(table))).run();
+      });
+  }
+
   createFilter (query) {
     return createFilter(query, this.options.r);
   }

--- a/src/index.js
+++ b/src/index.js
@@ -41,15 +41,16 @@ class Service {
     return Proto.extend(obj, this);
   }
 
-  init (table, opts = {}) {
+  init (opts = {}) {
     let r = this.options.r;
+    let t = this.options.name;
     let db = this.options.r._poolMaster._options.db;
 
     return r.dbList().contains(db) // create db if not exists
       .do(dbExists => r.branch(dbExists, {created: 0}, r.dbCreate(db))).run()
       .then(() => {
-        return r.db(db).tableList().contains(table) // create table if not exists
-          .do(tableExists => r.branch(tableExists, {created: 0}, r.tableCreate(table))).run();
+        return r.db(db).tableList().contains(t) // create table if not exists
+          .do(tableExists => r.branch(tableExists, {created: 0}, r.tableCreate(t))).run();
       });
   }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -202,3 +202,20 @@ describe('RethinkDB service example test', () => {
 
   example('id');
 });
+
+describe('init database', () => {
+  it('service.init() initializes the database', done => {
+    service({ Model: r, name: 'testTable' })
+      .init('testTable')
+      .then(() => {
+        expect(r.tableList().contains('testTable'));
+        r.table('testTable')
+          .delete(null)
+          .run()
+          .then(() => {
+            return done();
+          });
+      })
+      .catch(done);
+  });
+});

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -206,7 +206,7 @@ describe('RethinkDB service example test', () => {
 describe('init database', () => {
   it('service.init() initializes the database', done => {
     service({ Model: r, name: 'testTable' })
-      .init('testTable')
+      .init()
       .then(() => {
         expect(r.tableList().contains('testTable'));
         r.table('testTable')

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -195,10 +195,13 @@ describe('feathers-rethinkdb', () => {
 });
 
 describe('RethinkDB service example test', () => {
-  let server;
-
-  before(() => (server = require('../example/app')));
-  after(done => server.close(() => done()));
+  before(done => {
+    let server = require('../example/app');
+    server.then((s) => {
+      after(done => s.close(() => done()));
+      done();
+    });
+  });
 
   example('id');
 });
@@ -209,12 +212,11 @@ describe('init database', () => {
       .init()
       .then(() => {
         expect(r.tableList().contains('testTable'));
-        r.table('testTable')
-          .delete(null)
-          .run()
+        r.table('testTable').delete(null).run()
           .then(() => {
             return done();
-          });
+          })
+          .catch(done);
       })
       .catch(done);
   });


### PR DESCRIPTION
### overview
As per the discussion in #54 and feathersjs/feathers-generator#30 some databases (such as rethink) need to be initialized prior to mounting a service.

This PR adds `service({}).init()` which returns a promise and gracefully degrades if database is already initialized.

### tasks
- [x] add `init(opts={})`
- [x] update tests
- [x] implement in [generator](https://github.com/feathersjs/feathers-generator/blob/e211ab1badf92c6a30d89606567c27e12a4d0f1f/src/service/templates/models/rethinkdb/templates/service.model.js#L16)
- [x] update readme
- [x] update example
- [ ] update [docs](https://docs.feathersjs.com/databases/rethinkdb.htm://docs.feathersjs.com/databases/rethinkdb.html)

### other
closes #54, ref feathersjs/feathers-generator#30