### PR TITLE
Added missing params argument in calling _get method

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -213,7 +213,7 @@ class Service {
   }
 
   update (id, data, params) {
-    return this._get(id).then(getData => {
+    return this._get(id, params).then(getData => {
       data[this.id] = id;
       return this.table.get(getData[this.id])
         .replace(data, {


### PR DESCRIPTION
Fixed possibility to call service update method with id=null and specified params.
Previously there was error with undefined query.